### PR TITLE
Add sovereign gateway onboarding wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Omni Engineer is a spiritual successor to [Claude Engineer](https://github.com/D
 - `/list`: List files, searches, and images in memory
 - `/exec <command>`: Execute a shell command
 - `/atpost <text>`: Post a message to the AT Protocol Fedaverse
+- `/sovereign_gateway`: Launch the AT handle onboarding wizard for automated or manual DNS/DID setup
 - `/help`: Display available commands
 - `/model`: Show current AI model
 - `/change_model`: Change the AI model


### PR DESCRIPTION
## Summary
- add a sovereign gateway command to guide AT handle onboarding and fleet setup steps
- include the new onboarding wizard in the command palette and help table
- document the command in the README for discoverability

## Testing
- python -m compileall main.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69435c0be2588327971bae2604dfb6dc)