### PR TITLE
docs: clarify DomainAgent first implementation step (deterministic DNS planning core)

### DIFF
--- a/docs/domain-agent-first-step.md
+++ b/docs/domain-agent-first-step.md
@@ -2,6 +2,19 @@
 
 This repo now includes a `forge.domains` scaffold as the first implementation step for the Sovereign Gateway onboarding flow.
 
+## The first step to bring the agent to life
+
+Implement the **deterministic DNS planning core** first, before OAuth or live registrar writes.
+
+That means:
+
+1. Accept a `domain + did:plc` verification request.
+2. Compute the exact `_atproto` TXT record target (`did=did:plc:...`).
+3. Merge it against existing DNS records by removing conflicting `_atproto` values while preserving unrelated records.
+4. Return a reviewable before/after plan object.
+
+This is the highest-leverage first step because it creates a stable contract for every later phase (OAuth, API transport, polling, and UI) without risking accidental DNS mutations.
+
 ## What this enables now
 
 - A canonical `DomainVerificationRequest` object that turns a `did:plc:...` value into an `_atproto` TXT record.


### PR DESCRIPTION
### Motivation
- Provide a clear, implementation-ready first milestone for the Sovereign Gateway onboarding agent that isolates DNS planning from network/registrar side effects.

### Description
- Expanded `docs/domain-agent-first-step.md` with a focused “The first step to bring the agent to life” section that defines the deterministic DNS planning core and its responsibilities.
- The new guidance lists the concrete responsibilities: accept a `domain + did:plc` request, compute the `_atproto` TXT (`did=did:plc:...`), merge it against existing records by removing conflicting `_atproto` entries while preserving unrelated records, and return a reviewable before/after plan object.
- Kept the change documentation-only so the planner/agent codebase contract remains stable for subsequent tasks like OAuth transport, Namecheap API wiring, and DNS propagation polling.

### Testing
- Ran `PYTHONPATH=. pytest -q` which passed all tests (`4 passed`).
- Observed `pytest -q` fails in this environment without `PYTHONPATH` because the `forge` package is not installed in editable mode, which does not affect the repository-level unit tests when run with `PYTHONPATH=.`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6995fa7fe0c08327978a28f7c652d51c)