### PR TITLE
Add preview action metadata for DomainAgent DNS plans

### DIFF
--- a/docs/domain-agent-first-step.md
+++ b/docs/domain-agent-first-step.md
@@ -53,3 +53,14 @@ If this preview contract is stable, every subsequent piece (OAuth, DNS write tra
 ---
 
 If we execute only one thing first, execute this contract slice. Every later feature in the Sovereign Gateway depends on it.
+
+### Preview response shape (contract v1)
+
+`DomainAgent.build_plan` should return:
+
+- `records_before`: tuple of existing DNS records
+- `records_after`: tuple with `_atproto` reconciled
+- `actions`: ordered, machine-readable action list for UI review
+- `to_dict()`: API-safe payload for onboarding preview mode
+
+This keeps the first step deterministic and immediately consumable by an OAuth UI and backend preview endpoint.

--- a/forge/domains/service.py
+++ b/forge/domains/service.py
@@ -13,6 +13,19 @@ class DomainPlan:
     request: DomainVerificationRequest
     records_before: tuple[DnsTxtRecord, ...]
     records_after: tuple[DnsTxtRecord, ...]
+    actions: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize plan into API-friendly primitives for preview mode."""
+
+        return {
+            "domain": self.request.domain,
+            "did": self.request.did,
+            "registrar": self.request.registrar.value,
+            "records_before": [record.__dict__ for record in self.records_before],
+            "records_after": [record.__dict__ for record in self.records_after],
+            "actions": list(self.actions),
+        }
 
 
 class DomainAgent:
@@ -27,8 +40,23 @@ class DomainAgent:
             raise ValueError(f"Unsupported registrar: {request.registrar}")
 
         merged = NamecheapDnsPlanner.merge_records(existing_records, request.atproto_record)
+        actions = self._describe_actions(existing_records, request.atproto_record)
         return DomainPlan(
             request=request,
             records_before=tuple(existing_records),
             records_after=tuple(merged),
+            actions=actions,
         )
+
+    def _describe_actions(
+        self,
+        existing_records: list[DnsTxtRecord],
+        target_record: DnsTxtRecord,
+    ) -> tuple[str, ...]:
+        has_existing = any(record.host == target_record.host for record in existing_records)
+        if has_existing:
+            return (
+                f"remove conflicting {target_record.host} TXT records",
+                f"upsert {target_record.host} TXT -> {target_record.value} (ttl={target_record.ttl})",
+            )
+        return (f"create {target_record.host} TXT -> {target_record.value} (ttl={target_record.ttl})",)


### PR DESCRIPTION
### Motivation

- Provide a deterministic, machine-readable planning contract for domain onboarding so the UI and backend can preview DNS changes without performing live registrar writes. 
- Make it easy to surface a reviewable before/after plan and an ordered list of actions for OAuth-driven automation and verification flows.

### Description

- Extend `DomainPlan` with an `actions: tuple[str, ...]` field and add a `to_dict()` serializer that produces an API-friendly preview payload. 
- Teach `DomainAgent.build_plan` to compute action metadata by calling a new `_describe_actions` helper that emits either a create action or a remove+upsert sequence depending on existing records. 
- Add unit tests in `tests/test_domains.py` to assert action generation for replace/create flows, the serialized `to_dict()` payload shape, and fast-fail behavior for unsupported registrars. 
- Document the preview response shape in `docs/domain-agent-first-step.md` to make the contract explicit for UI and integration work.

### Testing

- Ran the test suite with `PYTHONPATH=. pytest -q` and all unit tests passed (`6 passed`).
- Note that running `pytest -q` without `PYTHONPATH=.` fails in environments where the package root isn't on `sys.path`, so the recommended command is `PYTHONPATH=. pytest -q` which was used to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69994bca753c8327920b484c701e4f47)