### PR TITLE
feat(domains): validate and normalize domain verification inputs

### DIFF
--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -8,6 +8,27 @@ def test_domain_request_builds_atproto_record():
     assert request.atproto_record == DnsTxtRecord(host="_atproto", value="did=did:plc:abc123", ttl=60)
 
 
+def test_domain_request_normalizes_domain_and_did():
+    request = DomainVerificationRequest(domain=" PrivateClient.AI. ", did=" did:plc:abc123 ")
+
+    assert request.domain == "privateclient.ai"
+    assert request.did == "did:plc:abc123"
+
+
+def test_domain_request_rejects_invalid_domain_or_did():
+    try:
+        DomainVerificationRequest(domain="invalid_domain", did="did:plc:abc123")
+        assert False, "Expected ValueError for invalid domain"
+    except ValueError as exc:
+        assert "Invalid domain" in str(exc)
+
+    try:
+        DomainVerificationRequest(domain="privateclient.ai", did="did:web:privateclient.ai")
+        assert False, "Expected ValueError for non-plc DID"
+    except ValueError as exc:
+        assert "did:plc:" in str(exc)
+
+
 def test_namecheap_planner_replaces_conflicting_atproto_record():
     existing = [
         DnsTxtRecord(host="@", value="example"),


### PR DESCRIPTION
### Motivation

- Ensure the DomainAgent planning core receives deterministic, normalized inputs so DNS plans are stable and reviewable.
- Prevent accidental or malformed values from producing incorrect `_atproto` TXT records by validating domain syntax and DID form.
- Make the planner unit-testable and safer to wire into OAuth-backed registrar writes later.

### Description

- Add a `DOMAIN_RE` regex and implement `__post_init__` on `DomainVerificationRequest` to normalize (trim, lowercase, strip trailing dot) and validate domains and DIDs in `forge/domains/models.py`.
- Enforce that DIDs start with `did:plc:` and raise `ValueError` on invalid input, while preserving the `atproto_record` property behavior.
- Add unit tests in `tests/test_domains.py` for normalization, invalid-domain rejection, and non-`did:plc:` rejection, alongside existing planner and DomainAgent tests.

### Testing

- Ran `pytest -q` which initially failed during collection due to local import path, so tests were re-run with `PYTHONPATH=.`.
- Executed `PYTHONPATH=. pytest -q tests/test_domains.py` and observed `6 passed` with all domain-related tests succeeding.
- Confirmed the modified files are `forge/domains/models.py` and `tests/test_domains.py` and that the deterministic planner tests still pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6999eef6e2888327b55fe96d555a78f8)