### PR TITLE
feat(domains): add DomainAgent.first_step helper for deterministic onboarding planning

### DIFF
--- a/docs/domain-agent-first-step.md
+++ b/docs/domain-agent-first-step.md
@@ -20,6 +20,7 @@ This is the highest-leverage first step because it creates a stable contract for
 - A canonical `DomainVerificationRequest` object that turns a `did:plc:...` value into an `_atproto` TXT record.
 - A deterministic `NamecheapDnsPlanner.merge_records(...)` function that removes conflicting `_atproto` entries and appends the desired value.
 - A `DomainAgent.build_plan(...)` orchestration seam that returns a full before/after DNS plan for safe review before API writes.
+- A `DomainAgent.first_step(...)` helper that accepts raw onboarding inputs (`domain`, `did`, and existing TXT records) and returns the same deterministic plan in one call.
 - A clean seam for the next milestone: adding OAuth-backed Namecheap transport calls without rewriting onboarding logic.
 
 ## Why this is the best first step

--- a/forge/domains/service.py
+++ b/forge/domains/service.py
@@ -18,6 +18,23 @@ class DomainPlan:
 class DomainAgent:
     """Application-facing orchestration layer for domain verification planning."""
 
+    def first_step(
+        self,
+        *,
+        domain: str,
+        did: str,
+        existing_records: list[DnsTxtRecord],
+        registrar: Registrar = Registrar.NAMECHEAP,
+    ) -> DomainPlan:
+        """Build the deterministic DNS plan used as onboarding step one.
+
+        This helper creates a validated request and then computes the
+        before/after DNS plan without touching registrar APIs.
+        """
+
+        request = DomainVerificationRequest(domain=domain, did=did, registrar=registrar)
+        return self.build_plan(request=request, existing_records=existing_records)
+
     def build_plan(
         self,
         request: DomainVerificationRequest,

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -72,3 +72,21 @@ def test_domain_agent_rejects_unknown_registrar():
         assert False, "Expected ValueError"
     except ValueError as exc:
         assert "Unsupported registrar" in str(exc)
+
+
+def test_domain_agent_first_step_builds_plan_from_raw_inputs():
+    plan = DomainAgent().first_step(
+        domain="PrivateClient.ai.",
+        did=" did:plc:new ",
+        existing_records=[
+            DnsTxtRecord(host="_atproto", value="did=did:plc:old"),
+            DnsTxtRecord(host="@", value="keep"),
+        ],
+    )
+
+    assert plan.request.domain == "privateclient.ai"
+    assert plan.request.did == "did:plc:new"
+    assert plan.records_after == (
+        DnsTxtRecord(host="@", value="keep"),
+        DnsTxtRecord(host="_atproto", value="did=did:plc:new", ttl=60),
+    )


### PR DESCRIPTION
### Motivation
- Provide a single-call, deterministic onboarding entry point that accepts raw inputs (`domain`, `did`, existing TXT records) and yields a safe before/after DNS plan without making network calls. 
- Isolate DNS planning logic from OAuth/registrar transport so UI and automation can review changes before any live mutation. 
- Make the onboarding contract unit-testable and stable for subsequent steps (OAuth, polling, registrar writes). 

### Description
- Added `DomainAgent.first_step(...)` which validates raw inputs via `DomainVerificationRequest` and returns a `DomainPlan` computed by `build_plan`; implemented in `forge/domains/service.py`. 
- Added unit test `test_domain_agent_first_step_builds_plan_from_raw_inputs` to `tests/test_domains.py` to cover normalization and deterministic merge behavior. 
- Updated documentation `docs/domain-agent-first-step.md` to mention the new `first_step(...)` helper as the first onboarding seam. 

### Testing
- Running `pytest -q` initially failed during collection in this environment due to the test import path not including the repo root. 
- Running `PYTHONPATH=. pytest -q tests/test_domains.py` executed the domain tests and reported `7 passed` (all domain-related tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6999f409d7888327b90afa41cce872e6)