### PR TITLE
Add JSON-ready DomainPlan.to_dict() for onboarding API integration

### DIFF
--- a/forge/domains/service.py
+++ b/forge/domains/service.py
@@ -14,6 +14,26 @@ class DomainPlan:
     records_before: tuple[DnsTxtRecord, ...]
     records_after: tuple[DnsTxtRecord, ...]
 
+    def to_dict(self) -> dict[str, object]:
+        """JSON-ready plan payload for UI and API review surfaces."""
+
+        return {
+            "request": {
+                "domain": self.request.domain,
+                "did": self.request.did,
+                "registrar": self.request.registrar.value,
+            },
+            "records_before": [
+                {"host": record.host, "value": record.value, "ttl": record.ttl}
+                for record in self.records_before
+            ],
+            "records_after": [
+                {"host": record.host, "value": record.value, "ttl": record.ttl}
+                for record in self.records_after
+            ],
+            "next_action": "review_and_apply_dns",
+        }
+
 
 class DomainAgent:
     """Application-facing orchestration layer for domain verification planning."""

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -90,3 +90,25 @@ def test_domain_agent_first_step_builds_plan_from_raw_inputs():
         DnsTxtRecord(host="@", value="keep"),
         DnsTxtRecord(host="_atproto", value="did=did:plc:new", ttl=60),
     )
+
+
+def test_domain_plan_to_dict_returns_api_ready_payload():
+    plan = DomainAgent().first_step(
+        domain="privateclient.ai",
+        did="did:plc:new",
+        existing_records=[DnsTxtRecord(host="@", value="keep")],
+    )
+
+    assert plan.to_dict() == {
+        "request": {
+            "domain": "privateclient.ai",
+            "did": "did:plc:new",
+            "registrar": "namecheap",
+        },
+        "records_before": [{"host": "@", "value": "keep", "ttl": 60}],
+        "records_after": [
+            {"host": "@", "value": "keep", "ttl": 60},
+            {"host": "_atproto", "value": "did=did:plc:new", "ttl": 60},
+        ],
+        "next_action": "review_and_apply_dns",
+    }


### PR DESCRIPTION
### Motivation
- Provide a stable, API/UI-friendly representation of the deterministic DNS plan so onboarding flows can review and apply updates without coupling to Python dataclasses.
- Decouple the planning core from registrar transport and OAuth so the agent can produce verifiable before/after DNS plans safely.
- Prepare a clear handoff payload (`next_action`) for the next step in the onboarding agent pipeline.

### Description
- Add `DomainPlan.to_dict()` in `forge/domains/service.py` which returns a JSON-ready payload containing `request` metadata, `records_before`, `records_after`, and a `next_action` string.
- Ensure TXT record entries are serialized as objects with `host`, `value`, and `ttl` for direct consumption by API routes and UI components.
- Add a unit test `test_domain_plan_to_dict_returns_api_ready_payload` in `tests/test_domains.py` that validates the exact payload shape returned by `to_dict()`.

### Testing
- Ran `PYTHONPATH=. pytest -q` and all tests passed (`8 passed`).
- The new test exercizes the `to_dict()` output shape and existing planner behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6999f97b35b88327b78d56c3f4ed2455)